### PR TITLE
Add check for identity attestation before checking criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Example output:
 ```
 <example:product:1:claim:1> result:verifiedCriterion <https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly>.
 <example:product:1:claim:1> result:dependsOn <http://localhost/credentials/untp-dcc-simple.json>.
-<http://localhost/credentials/untp-dpp-simple.json> result:trusts <http://localhost/credentials/untp-dcc-simple.json>.
+<http://localhost/credentials/untp-dpp-simple.json> result:claimsAttestedBy <http://localhost/credentials/untp-dcc-simple.json>.
 <example:product:1:claim:2> result:verifiedCriterion <https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryDisposal>.
 <example:product:1:claim:2> result:dependsOn <http://localhost/credentials/untp-dcc-simple.json>.
 <example:product:1:claim:2> result:verifiedCriterion <https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryRecycling>.
@@ -116,7 +116,7 @@ $ npm run query -- credential-graph.n3 src/core/inferences/10-infer-product-clai
 
 <example:product:1:claim:1> result:verifiedCriterion <https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly>.
 <example:product:1:claim:1> result:dependsOn <http://localhost/credentials/untp-dcc-simple.json>.
-<http://localhost/credentials/untp-dpp-simple.json> result:trusts <http://localhost/credentials/untp-dcc-simple.json>.
+<http://localhost/credentials/untp-dpp-simple.json> result:claimsAttestedBy <http://localhost/credentials/untp-dcc-simple.json>.
 <example:product:1:claim:2> result:verifiedCriterion <https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryDisposal>.
 <example:product:1:claim:2> result:dependsOn <http://localhost/credentials/untp-dcc-simple.json>.
 <example:product:1:claim:2> result:verifiedCriterion <https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryRecycling>.
@@ -202,3 +202,4 @@ I don't currently have a (non-personal) repo for this yet, so rather than creati
 - Investigate further whether there's a more "drop-in" way to include new queries. The main issue is that to present results, the query result needs to be parsed into relevant structs by the core library, and returned to the CLI (or web) interface.
 - Check whether the VSCode plugin's support for debugging can be used with the eye-js reasoner which is already installed with the repo.
 - Update the tier3Validators to use the `ValidationResult` consistently with other core tiers.
+- Ensure that credentials are within their validity dates to be considered.

--- a/example-credentials/conformity-credential-simple.json
+++ b/example-credentials/conformity-credential-simple.json
@@ -12,7 +12,7 @@
     "type": [
       "CredentialIssuer"
     ],
-    "id": "did:web:identifiers.electronic-certifier.com:12345",
+    "id": "did:web:identifiers.electronic-certifier.com",
     "name": "Electronic Certifier Pty Ltd"
   },
   "validFrom": "2024-03-15T12:00:00Z",

--- a/example-credentials/identity-anchor-for-dcc-issuer.json
+++ b/example-credentials/identity-anchor-for-dcc-issuer.json
@@ -1,0 +1,27 @@
+{
+  "type": [
+    "DigitalIdentityAnchor",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://test.uncefact.org/vocabulary/untp/dia/0.6.0-beta12/"
+  ],
+  "id": "http://localhost/credentials/identity-anchor-for-dcc-issuer.json",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:abr.business.gov.au:ABN:90664869327",
+    "name": "Certifier Trusted By Gov Pty Ltd"
+  },
+  "validFrom": "2024-03-15T12:00:00Z",
+  "validUntil": "2034-03-15T12:00:00Z",
+  "credentialSubject": {
+    "type": [
+      "RegisteredIdentity"
+    ],
+    "id": "did:web:identifiers.electronic-certifier.com:12345",
+    "name": "Electronic Certifier Pty Ltd"
+  }
+}

--- a/example-credentials/identity-anchor-for-dcc-issuer.json
+++ b/example-credentials/identity-anchor-for-dcc-issuer.json
@@ -13,7 +13,7 @@
       "CredentialIssuer"
     ],
     "id": "did:web:abr.business.gov.au:ABN:90664869327",
-    "name": "Certifier Trusted By Gov Pty Ltd"
+    "name": "Certifier with Registered Business Pty Ltd"
   },
   "validFrom": "2024-03-15T12:00:00Z",
   "validUntil": "2034-03-15T12:00:00Z",
@@ -21,7 +21,7 @@
     "type": [
       "RegisteredIdentity"
     ],
-    "id": "did:web:identifiers.electronic-certifier.com:12345",
+    "id": "did:web:identifiers.electronic-certifier.com",
     "name": "Electronic Certifier Pty Ltd"
   }
 }

--- a/example-credentials/identity-anchor-for-dia-issuer.json
+++ b/example-credentials/identity-anchor-for-dia-issuer.json
@@ -1,0 +1,27 @@
+{
+  "type": [
+    "DigitalIdentityAnchor",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://test.uncefact.org/vocabulary/untp/dia/0.6.0-beta12/"
+  ],
+  "id": "http://localhost/credentials/identity-anchor-for-dia-issuer.json",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:department.gov.au:depId:123456",
+    "name": "Government Department"
+  },
+  "validFrom": "2024-03-15T12:00:00Z",
+  "validUntil": "2034-03-15T12:00:00Z",
+  "credentialSubject": {
+    "type": [
+      "RegisteredIdentity"
+    ],
+    "id": "did:web:abr.business.gov.au:ABN:90664869327",
+    "name": "Certifier Trusted By Gov Pty Ltd"
+  }
+}

--- a/example-credentials/identity-anchor-for-dia-issuer.json
+++ b/example-credentials/identity-anchor-for-dia-issuer.json
@@ -12,7 +12,7 @@
     "type": [
       "CredentialIssuer"
     ],
-    "id": "did:web:department.gov.au:depId:123456",
+    "id": "did:web:abr.business.gov.au",
     "name": "Government Department"
   },
   "validFrom": "2024-03-15T12:00:00Z",

--- a/example-credentials/identity-anchor-for-dpp-issuer.json
+++ b/example-credentials/identity-anchor-for-dpp-issuer.json
@@ -1,0 +1,27 @@
+{
+  "type": [
+    "DigitalIdentityAnchor",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://test.uncefact.org/vocabulary/untp/dia/0.6.0-beta12/"
+  ],
+  "id": "http://localhost/credentials/identity-anchor-for-dia-issuer.json",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:abr.business.gov.au",
+    "name": "Government Department"
+  },
+  "validFrom": "2024-03-15T12:00:00Z",
+  "validUntil": "2034-03-15T12:00:00Z",
+  "credentialSubject": {
+    "type": [
+      "RegisteredIdentity"
+    ],
+    "id": "did:web:battery-company.com",
+    "name": "Battery Company Pty Ltd"
+  }
+}

--- a/example-credentials/product-passport-simple.json
+++ b/example-credentials/product-passport-simple.json
@@ -12,7 +12,7 @@
     "type": [
       "CredentialIssuer"
     ],
-    "id": "did:web:identifiers.battery-company.com:12345",
+    "id": "did:web:battery-company.com",
     "name": "Battery Company Pty Ltd",
     "issuerAlsoKnownAs": [
       {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,10 @@ export async function runCLI(args: string[] = process.argv): Promise<void> {
     .option('-v, --verbose', 'display detailed validation information')
     .option('-d, --dir <directory>', 'validate all JSON and JSONLD files in the specified directory')
     .option('--save-graph', 'save the RDF graph to a file (credential-graph.ttl)')
+    .option('--trust-did <did>', 'explicitly trust this DID (can be used multiple times)', (did, prev) => {
+      prev.push(did);
+      return prev;
+    }, [])
     .argument('[files...]', 'UNTP credential files to validate')
     .action(async (files: string[], options) => {
       try {
@@ -68,7 +72,7 @@ export async function runCLI(args: string[] = process.argv): Promise<void> {
         console.log(chalk.green('\n✓ All files passed Tier 2 tests (valid UNTP credentials)'));
 
         // Proceed to Tier 3 checks if all files passed Tier 2
-        const tier3Result = await tier3ChecksForGraph(data, options.verbose, options.saveGraph);
+        const tier3Result = await tier3ChecksForGraph(data, options.verbose, options.saveGraph, options.trustDid || []);
 
         // Check if all files were successfully added to the graph
         if (tier3Result.validFiles !== tier3Result.totalFiles) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ export async function runCLI(args: string[] = process.argv): Promise<void> {
     .option('-v, --verbose', 'display detailed validation information')
     .option('-d, --dir <directory>', 'validate all JSON and JSONLD files in the specified directory')
     .option('--save-graph', 'save the RDF graph to a file (credential-graph.ttl)')
-    .option('--trust-did <did>', 'explicitly trust this DID (can be used multiple times)', (did, prev) => {
+    .option('--trust-did <did>', 'explicitly trust this DID (can be used multiple times)', (did, prev: string[]) => {
       prev.push(did);
       return prev;
     }, [])

--- a/src/cli/tier3.ts
+++ b/src/cli/tier3.ts
@@ -43,17 +43,17 @@ async function checkProductClaims(
       console.log(chalk.cyan(`    Product: "${product.name}" (${product.id})`));
 
       let unattestedIssuers = await getUnattestedIssuersForProduct(store, product.dppId);
-      
+
       // Filter out explicitly trusted DIDs
       if (trustedDIDs.length > 0 && unattestedIssuers.length > 0) {
         const originalCount = unattestedIssuers.length;
         unattestedIssuers = unattestedIssuers.filter(issuer => !trustedDIDs.includes(issuer));
-        
+
         if (originalCount > unattestedIssuers.length) {
           console.log(chalk.yellow(`      ℹ Filtered out ${originalCount - unattestedIssuers.length} trusted DIDs from unattested issuers`));
         }
       }
-      
+
       if (unattestedIssuers.length > 0) {
         console.log(chalk.red(`      ⚠ Unattested issuers: ${unattestedIssuers.join(', ')}`));
         // Stop processing further claims if there are unattested issuers
@@ -206,7 +206,7 @@ export async function tier3ChecksForGraph(
     const claimResults = await checkProductClaims(store, verbose, trustedDIDs);
 
     if (claimResults.hasUnattestedIssuers) {
-      console.log(chalk.red(`  ✗ Validation failed due to unattested issuers in the trust chain`));
+      console.log(chalk.red(`  ✗ Validation failed due to unattested issuers in the trust chain. You can explicitly add DIDs for issuers you trust using the --trust-did option.`));
     } else if (claimResults.valid) {
       console.log(chalk.green(`  ✓ All ${claimResults.totalClaims} product claims are verified by attestations`));
     } else if (claimResults.totalClaims === 0) {

--- a/src/cli/tier3.ts
+++ b/src/cli/tier3.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk';
 import { ValidationResult } from '../core/types.js';
-import { createRDFGraph, saveGraphToFiles, listAllProductClaimCriteria, runInferences } from '../core/tier3Validators.js';
+import { createRDFGraph, saveGraphToFiles, listAllProductClaimCriteria, runInferences, getUnattestedIssuersForProduct } from '../core/tier3Validators.js';
 import { Store } from 'n3';
+import { get } from 'http';
 
 /**
  * Checks product claims in the RDF graph and verifies if they are attested
@@ -38,6 +39,13 @@ async function checkProductClaims(
     // Process the products and their claims
     for (const product of products) {
       console.log(chalk.cyan(`    Product: "${product.name}" (${product.id})`));
+
+      const unattestedIssuers = await getUnattestedIssuersForProduct(store, product.id);
+      if (unattestedIssuers.length > 0) {
+        console.log(chalk.red(`      ⚠ Unattested issuers: ${unattestedIssuers.join(', ')}`));
+      } else {
+        console.log(chalk.green(`      ✓ All issuers are attested`));
+      }
 
       for (const claim of product.claims) {
         totalClaims++;

--- a/src/cli/tier3.ts
+++ b/src/cli/tier3.ts
@@ -40,7 +40,7 @@ async function checkProductClaims(
     for (const product of products) {
       console.log(chalk.cyan(`    Product: "${product.name}" (${product.id})`));
 
-      const unattestedIssuers = await getUnattestedIssuersForProduct(store, product.id);
+      const unattestedIssuers = await getUnattestedIssuersForProduct(store, product.dppId);
       if (unattestedIssuers.length > 0) {
         console.log(chalk.red(`      ⚠ Unattested issuers: ${unattestedIssuers.join(', ')}`));
       } else {

--- a/src/core/inferences/10-infer-product-claim-criteria-verified.n3
+++ b/src/core/inferences/10-infer-product-claim-criteria-verified.n3
@@ -49,9 +49,9 @@
 {
    # The inference here is that a specific criterion of a claim is verified, and
    # that (at least part of) a claim has been verified by a specific conformance
-   # credential, and at a higher level, that the DPP trusts
-   # the specific DCC.
+   # credential, and at a higher level, that our trust in the DPP relies the
+   # specific DCC.
    ?claim result:verifiedCriterion ?criterion .
    ?claim result:dependsOn ?dccCredential .
-   ?dppCredential result:trusts ?dccCredential .
+   ?dppCredential result:claimsAttestedBy ?dccCredential .
 } .

--- a/src/core/inferences/30-infer-identity-verified.n3
+++ b/src/core/inferences/30-infer-identity-verified.n3
@@ -1,0 +1,30 @@
+@prefix dia: <https://test.uncefact.org/vocabulary/untp/dia/0/> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix result: <http://example.org/result#> .
+@prefix untp: <https://test.uncefact.org/vocabulary/untp/core/0/> .
+@prefix vc: <https://www.w3.org/2018/credentials#> .
+
+# This query infers whether the issuer of a verified credential has
+# its identity verified by a DIA.
+{
+    # Find all verified credentials.
+   ?credential a vc:VerifiableCredential .
+   ?credential vc:issuer ?credentialIssuer .
+
+   # Find DigitalIdentityAnchors where the DIA credentialSubject matches
+   # the issuer of the verified credential.
+   ?dia a dia:DigitalIdentityAnchor .
+   ?dia vc:credentialSubject ?credentialSubject .
+   ?credentialSubject log:equalTo ?credentialIssuer .
+}
+=> 
+{
+   ?credential result:issuerIdentityAttestedBy ?dia .
+} .
+
+# It seems there's different trust graphs - an identity trust graph for a DPP
+# will need to check not only the identity of the issuer of the DPP, but also
+# that of any DCC which attests to claims made by the DPP.
+# A claim trust graph (better name) needs to check that the issuer of the DCC is trusted to check the criteria types to which they've attested.

--- a/src/core/tier3Validators.ts
+++ b/src/core/tier3Validators.ts
@@ -392,11 +392,11 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
  * from each credential issuer via DigitalIdentityAnchors (if any), returning
  * the issuers of the credentials that are not attested.
  * @param store - The N3 Store containing the RDF graph
- * @param productId - The ID of the product to check
+ * @param dppId - The ID of the Digital Product Passport to check
  * @returns Promise with an array of unattested issuer IDs
  * @throws Error if the query fails.
  */
-export async function getUnattestedIssuersForProduct(store: Store, productId: string): Promise<string[]> {
+export async function getUnattestedIssuersForProduct(store: Store, dppId: string): Promise<string[]> {
   // Just a stub returning an empty array for now
   return new Promise((resolve, reject) => {
     return resolve(["did:web:example.com:issuer2"]);

--- a/src/core/tier3Validators.ts
+++ b/src/core/tier3Validators.ts
@@ -26,6 +26,7 @@ interface Product {
   id: string;
   name: string;
   claims: Claim[];
+  dppId: string;  // ID of the Digital Product Passport this product belongs to
 }
 
 const { namedNode } = DataFactory;
@@ -195,7 +196,7 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
       PREFIX vc: <https://www.w3.org/2018/credentials#>
       PREFIX result: <http://example.org/result#>
 
-      SELECT ?product ?productName ?claim ?topic ?conformance ?criterion ?criterionName
+      SELECT ?credential ?product ?productName ?claim ?topic ?conformance ?criterion ?criterionName
              (EXISTS { ?claim result:allCriteriaVerified true } AS ?claimVerified)
              (EXISTS { ?claim result:verifiedCriterion ?criterion } AS ?criterionVerified)
       WHERE {
@@ -223,6 +224,7 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
 
     // Process each binding (row of results) using async iteration
     for await (const binding of result) {
+      const dppId = binding.get('credential')?.value || '';
       const productId = binding.get('product')?.value || '';
       const productName = binding.get('productName')?.value || '';
       const claimId = binding.get('claim')?.value || '';
@@ -238,7 +240,8 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
         productsMap.set(productId, {
           id: productId,
           name: productName,
-          claims: []
+          claims: [],
+          dppId: dppId
         });
       }
 
@@ -314,7 +317,7 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
       PREFIX vc: <https://www.w3.org/2018/credentials#>
       PREFIX result: <http://example.org/result#>
 
-      SELECT ?product ?productName ?claim ?topic ?conformance
+      SELECT ?credential ?product ?productName ?claim ?topic ?conformance
              (EXISTS { ?claim result:allCriteriaVerified true } AS ?claimVerified)
       WHERE {
         ?credential a dpp:DigitalProductPassport .
@@ -336,6 +339,7 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
 
     // Process simple claims
     for await (const binding of simpleClaimsResult) {
+      const dppId = binding.get('credential')?.value || '';
       const productId = binding.get('product')?.value || '';
       const productName = binding.get('productName')?.value || '';
       const claimId = binding.get('claim')?.value || '';
@@ -348,7 +352,8 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
         productsMap.set(productId, {
           id: productId,
           name: productName,
-          claims: []
+          claims: [],
+          dppId: dppId
         });
       }
 

--- a/src/core/tier3Validators.ts
+++ b/src/core/tier3Validators.ts
@@ -428,10 +428,9 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
     const issuerResult = await myEngine.queryBindings(`
       PREFIX vc: <https://www.w3.org/2018/credentials#>
       
-      SELECT ?credential ?issuerId
+      SELECT ?credential ?issuer
       WHERE {
         ?credential vc:issuer ?issuer .
-        ?issuer rdf:ID|vc:id|@id ?issuerId .
         
         # Filter to only include our credentials of interest
         VALUES ?credential {
@@ -447,9 +446,9 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
     
     // Process the results
     for await (const binding of issuerResult) {
-      const issuerId = binding.get('issuerId')?.value;
-      if (issuerId && !issuerIds.includes(issuerId)) {
-        issuerIds.push(issuerId);
+      const issuer = binding.get('issuer')?.value;
+      if (issuer && !issuerIds.includes(issuer)) {
+        issuerIds.push(issuer);
       }
     }
 

--- a/src/core/tier3Validators.ts
+++ b/src/core/tier3Validators.ts
@@ -380,3 +380,20 @@ export async function listAllProductClaimCriteria(store: Store): Promise<Product
   }
 }
 
+
+/**
+ * Checks a DPP's dependencies to get a set of verifiable credentials required
+ * to support the claims of the product passport, then follows the trust chain
+ * from each credential issuer via DigitalIdentityAnchors (if any), returning
+ * the issuers of the credentials that are not attested.
+ * @param store - The N3 Store containing the RDF graph
+ * @param productId - The ID of the product to check
+ * @returns Promise with an array of unattested issuer IDs
+ * @throws Error if the query fails.
+ */
+export async function getUnattestedIssuersForProduct(store: Store, productId: string): Promise<string[]> {
+  // Just a stub returning an empty array for now
+  return new Promise((resolve, reject) => {
+    return resolve(["did:web:example.com:issuer2"]);
+  })
+}

--- a/src/core/tier3Validators.ts
+++ b/src/core/tier3Validators.ts
@@ -446,7 +446,7 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
     });
 
     // Log the attestation chains for debugging
-    console.log('Attestation chains:');
+    // console.log('Attestation chains:');
     const attestationChains: Record<string, string[]> = {};
     const attestedCredentials = new Set<string>();
     const allCredentials = new Set<string>(credentialIds);
@@ -460,11 +460,11 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
       }
 
       attestationChains[credential].push(dia);
-      console.log(`Credential ${credential} is attested by DIA ${dia}`);
-      
+      // console.log(`Credential ${credential} is attested by DIA ${dia}`);
+
       // Mark this credential as attested
       attestedCredentials.add(credential);
-      
+
       // Add the DIA to our list of all credentials
       allCredentials.add(dia);
     }
@@ -480,7 +480,7 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
       WHERE {
         # Filter to only include our unattested credentials
         VALUES ?credential { ${unattestatedCredentials.map(id => `<${id}>`).join(' ')} }
-        
+
         # Get the issuer for each credential
         ?credential vc:issuer ?issuer .
       }

--- a/src/core/tier3Validators.ts
+++ b/src/core/tier3Validators.ts
@@ -432,17 +432,14 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
     // for which we need to ensure we trust the issuers.
 
 
-    // Use a SPARQL path query to find all attestation chains
+    // Use a SPARQL path query to find all identity attestation chains
     const attestationResult = await myEngine.queryBindings(`
       PREFIX result: <http://example.org/result#>
 
-      SELECT ?credential ?ultimateDia
+      SELECT ?credential ?dia
       WHERE {
-        # Filter to only include our relevant credentials
-        VALUES ?credential { ${credentialIds.map(id => `<${id}>`).join(' ')} }
-        
         # Find all DIAs in the attestation chain using property path
-        ?credential result:issuerIdentityAttestedBy+ ?ultimateDia .
+        ?credential result:issuerIdentityAttestedBy ?dia .
       }
     `, {
       sources: [store]
@@ -451,19 +448,19 @@ export async function getUnattestedIssuersForProduct(store: Store, dppId: string
     // Log the attestation chains for debugging
     console.log('Attestation chains:');
     const attestationChains: Record<string, string[]> = {};
-    
+
     for await (const binding of attestationResult) {
       const credential = binding.get('credential')?.value || '';
-      const ultimateDia = binding.get('ultimateDia')?.value || '';
-      
+      const dia = binding.get('dia')?.value || '';
+
       if (!attestationChains[credential]) {
         attestationChains[credential] = [];
       }
-      
-      attestationChains[credential].push(ultimateDia);
-      console.log(`Credential ${credential} is attested by DIA ${ultimateDia}`);
+
+      attestationChains[credential].push(dia);
+      console.log(`Credential ${credential} is attested by DIA ${dia}`);
     }
-    
+
     // For now, just return an empty array as we're still developing this feature
     return [];
   } catch (error) {


### PR DESCRIPTION
This PR adds an extra inference rule, which is applied automatically, annotating which credentials have their identities attested to by which DIA's.

This inferred information is then used during the tier 3 checks new `getUnattestedIssuersForProduct()`, which is called for each product. This function will:

1. Query the graph for all credentials for which the DPP has `claimsAttestedBy` (so any DCCs which are attesting to claim criteria), so that we then have all credentials which we need to ensure we trust the issuers, then
2. uses the newly inferred `identityAttestedBy` predicate to find all credentials which have their identity attested
3. Uses 1 and 2 to find which credential issuers aren't attested for, for this given product context (this can include chained DIAs)

The example data is updated so that the DCC issuer has a DIA from the related ABN DID for the company, and that ABN DID has a DIA attestation from main business.gov.au DID. The Product issuer is attested to directly by a separate business.gov.au DID (just for simplicity).

So when running by default, without any explicit trust, the tier 3 tests are stopped as shown below:
![image](https://github.com/user-attachments/assets/95b3e7ff-3abf-4c78-bb67-d313c622c9e2)

Note the: 
```
Tier 3 testing - analyzing graph of combined credentials
  ✓ Successfully applied inference rules to the graph
    Product: "EV battery 300Ah" (https://id.gs1.org/01/09520123456788/21/12345)
      ⚠ Unattested issuers: did:web:abr.business.gov.au
  ✗ Validation failed due to unattested issuers in the trust chain. You can explicitly add DIDs for issuers you trust using the --trust-did option.
```

You can then run and say that you explicitly trust abr.business.gov.au, using the `--trust-did` option as shown below:
![image](https://github.com/user-attachments/assets/350ad698-4111-4966-8dcb-ad7bb95c2843)
...
![image](https://github.com/user-attachments/assets/c16a4e55-92ac-4bf8-9891-77209e6db3c2)

Note the:
```
Tier 3 testing - analyzing graph of combined credentials
  ✓ Successfully applied inference rules to the graph
    Product: "EV battery 300Ah" (https://id.gs1.org/01/09520123456788/21/12345)
      ℹ Filtered out 1 trusted DIDs from unattested issuers
      ✓ All issuers are attested

```